### PR TITLE
feat: Add DiscountProgram schema for discount scraper

### DIFF
--- a/api/schema/objects.go
+++ b/api/schema/objects.go
@@ -125,6 +125,17 @@ type Organization struct {
 	Picture_data   string             `bson:"picture_data" json:"picture_data"`
 }
 
+type DiscountProgram struct {
+	Id       primitive.ObjectID `bson:"_id" json:"_id"`
+	Category string             `bson:"category" json:"category"`
+	Business string             `bson:"business" json:"business"`
+	Address  string             `bson:"address" json:"address"`
+	Phone    string             `bson:"phone" json:"phone"`
+	Email    string             `bson:"email" json:"email"`
+	Website  string             `bson:"website" json:"website"`
+	Discount string             `bson:"discount" json:"discount"`
+}
+
 type Event struct {
 	Id                 primitive.ObjectID `bson:"_id" json:"_id"`
 	Summary            string             `bson:"summary" json:"summary"`


### PR DESCRIPTION
# Add DiscountProgram Schema

## Summary

Adds `DiscountProgram` schema to support the new discount programs scraper.

Enables storing and serving 205+ student discount programs from UTD Student Government's Comet Discount Program (https://sg.utdallas.edu/discount/).

**Related to UTDNebula/api-tools#109**

## Changes

**Modified**: `api/schema/objects.go` (+9 lines)

Added new schema:
```go
type DiscountProgram struct {
    Id       primitive.ObjectID `bson:"_id" json:"_id"`
    Category string             `bson:"category" json:"category"`
    Business string             `bson:"business" json:"business"`
    Address  string             `bson:"address" json:"address"`
    Phone    string             `bson:"phone" json:"phone"`
    Email    string             `bson:"email" json:"email"`
    Website  string             `bson:"website" json:"website"`
    Discount string             `bson:"discount" json:"discount"`
}
```

## Related PRs

- **api-tools PR #110**: Implements the scraper/parser (depends on this being merged first)

## Impact

- ✅ No breaking changes
- ✅ New schema only, no logic changes
- ✅ ~205 discount programs, ~500KB data
