### PR TITLE
Public URL in storage

### DIFF
--- a/api/controllers/storage.go
+++ b/api/controllers/storage.go
@@ -3,8 +3,10 @@ package controllers
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -176,7 +178,15 @@ func ObjectInfo(c *gin.Context) {
 		return
 	}
 
-	objectInfo := schema.ObjectInfoFromAttrs(attrs)
+	// Generate public URL
+	escapedObject := url.PathEscape(objectID)
+	url := fmt.Sprintf(
+		"https://storage.googleapis.com/%s/%s",
+		bucket,
+		escapedObject,
+	)
+
+	objectInfo := schema.ObjectInfoFromAttrs(attrs, url)
 	respond(c, http.StatusOK, "success", objectInfo)
 }
 
@@ -232,13 +242,22 @@ func PostObject(c *gin.Context) {
 		return
 	}
 
+	// Get object attributes
 	attrs, err := objectHandle.Attrs(ctx)
 	if err != nil {
 		respondWithInternalError(c, err)
 		return
 	}
 
-	objectInfo := schema.ObjectInfoFromAttrs(attrs)
+	// Generate public URL
+	escapedObject := url.PathEscape(objectID)
+	url := fmt.Sprintf(
+		"https://storage.googleapis.com/%s/%s",
+		bucket,
+		escapedObject,
+	)
+
+	objectInfo := schema.ObjectInfoFromAttrs(attrs, url)
 	respond(c, http.StatusOK, "success", objectInfo)
 }
 

--- a/api/schema/objects.go
+++ b/api/schema/objects.go
@@ -260,9 +260,10 @@ type ObjectInfo struct {
 	MediaLink       string    `bson:"media_link" json:"media_link"`
 	Created         time.Time `bson:"created" json:"created"`
 	Updated         time.Time `bson:"updated" json:"updated"`
+	PublicUrl       string    `bson:"public_url" json:"public_url"`
 }
 
-func ObjectInfoFromAttrs(attrs *storage.ObjectAttrs) ObjectInfo {
+func ObjectInfoFromAttrs(attrs *storage.ObjectAttrs, url string) ObjectInfo {
 	// Don't show the bucket prefix externally
 	bucketName, _ := strings.CutPrefix(attrs.Bucket, BUCKET_PREFIX)
 	return ObjectInfo{
@@ -275,6 +276,7 @@ func ObjectInfoFromAttrs(attrs *storage.ObjectAttrs) ObjectInfo {
 		attrs.MediaLink,
 		attrs.Created,
 		attrs.Updated,
+		url,
 	}
 }
 


### PR DESCRIPTION
Build a public URL for cloud storage and return it.

This can be used instead of the media link as an actual public url, not an API URL.