### PR TITLE
Updated autocomplete schema to match new Mongodb pipeline

### DIFF
--- a/api/schema/autocomplete_objects.go
+++ b/api/schema/autocomplete_objects.go
@@ -19,6 +19,7 @@ type AcademicSessionSections struct {
 type SectionNumberProfessors struct {
 	Professors     []SimpleProfessor `bson:"professors" json:"professors" schema:"professors"`
 	Section_number string            `bson:"section_number" json:"section_number" schema:"section_number"`
+	Total_students int               `bson:"total_students" json:"total_students" schema:"total_students"`
 }
 
 type SimpleAcademicSession struct {


### PR DESCRIPTION
Modified the autocomplete schema to include the total_students field from the new data aggregation pipeline in Mongodb. It follows the same naming format as the other properties of the structs. 