### PR TITLE
changed DiscountProgram.Address type to []string

### DIFF
--- a/api/docs/docs.go
+++ b/api/docs/docs.go
@@ -3940,7 +3940,10 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "address": {
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "business": {
                     "type": "string"

--- a/api/docs/swagger.yaml
+++ b/api/docs/swagger.yaml
@@ -502,7 +502,9 @@ definitions:
       _id:
         type: string
       address:
-        type: string
+        items:
+          type: string
+        type: array
       business:
         type: string
       category:

--- a/api/schema/objects.go
+++ b/api/schema/objects.go
@@ -129,7 +129,7 @@ type DiscountProgram struct {
 	Id       primitive.ObjectID `bson:"_id" json:"_id"`
 	Category string             `bson:"category" json:"category"`
 	Business string             `bson:"business" json:"business"`
-	Address  string             `bson:"address" json:"address"`
+	Address  []string           `bson:"address" json:"address"`
 	Phone    string             `bson:"phone" json:"phone"`
 	Email    string             `bson:"email" json:"email"`
 	Website  string             `bson:"website" json:"website"`


### PR DESCRIPTION
allows for multiple addresses to be stored as individual strings rather than one long string of addresses

this change is needed for api-tools to be able to work with addresses this way